### PR TITLE
feat: Copy magic patterns optimized prompt

### DIFF
--- a/apps/web/components/icons/index.tsx
+++ b/apps/web/components/icons/index.tsx
@@ -12,6 +12,7 @@ import { TerminalIcon } from "./terminal"
 import { ClapIcon } from "./clap"
 import { WorkflowIcon } from "./workslow"
 import { LogoutIcon } from "./logout-icon"
+import { MagicPatternsLogo } from "./magic-patterns"
 
 export type Icon = LucideIcon
 
@@ -198,4 +199,5 @@ export const Icons = {
       />
     </svg>
   ),
+  magicPatterns: MagicPatternsLogo,
 }

--- a/apps/web/components/icons/magic-patterns.tsx
+++ b/apps/web/components/icons/magic-patterns.tsx
@@ -1,5 +1,6 @@
 export const MagicPatternsLogo = ({ className }: { className?: string }) => (
   <svg
+    className={className}
     width="85"
     height="85"
     viewBox="0 0 85 85"

--- a/apps/web/components/icons/magic-patterns.tsx
+++ b/apps/web/components/icons/magic-patterns.tsx
@@ -1,0 +1,73 @@
+export const MagicPatternsLogo = ({ className }: { className?: string }) => (
+  <svg
+    width="85"
+    height="85"
+    viewBox="0 0 85 85"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M0 42.5C0 19.0279 19.0279 0 42.5 0V42.5H0Z"
+      fill="url(#paint0_radial_2210_64)"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M0 85C0 61.5279 19.0279 42.5 42.5 42.5V85H0Z"
+      fill="url(#paint1_radial_2210_64)"
+    />
+    <path
+      d="M63.75 42.5C75.4861 42.5 85 32.986 85 21.25C85 9.51395 75.4861 0 63.75 0C52.014 0 42.5 9.51395 42.5 21.25C42.5 32.986 52.014 42.5 63.75 42.5Z"
+      fill="url(#paint2_radial_2210_64)"
+    />
+    <path d="M42.5 42.5H85V85L42.5 42.5Z" fill="url(#paint3_radial_2210_64)" />
+    <defs>
+      <radialGradient
+        id="paint0_radial_2210_64"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientUnits="userSpaceOnUse"
+        gradientTransform="translate(79.9 85) rotate(-124.042) scale(107.503)"
+      >
+        <stop stopColor="#8DA4EF" stopOpacity="0.39" />
+        <stop offset="1" stopColor="#6A86E0" stopOpacity="0.752337" />
+      </radialGradient>
+      <radialGradient
+        id="paint1_radial_2210_64"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientUnits="userSpaceOnUse"
+        gradientTransform="translate(75.48 8.16) rotate(137.31) scale(113.328)"
+      >
+        <stop stopColor="#DD647C" />
+        <stop offset="1" stopColor="#F6D8DE" />
+      </radialGradient>
+      <radialGradient
+        id="paint2_radial_2210_64"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientUnits="userSpaceOnUse"
+        gradientTransform="translate(70.55 69.53) rotate(-132.951) scale(77.3433)"
+      >
+        <stop stopColor="#EC7B46" />
+        <stop offset="1" stopColor="#F4BDA3" />
+      </radialGradient>
+      <radialGradient
+        id="paint3_radial_2210_64"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientUnits="userSpaceOnUse"
+        gradientTransform="translate(83.385 49.045) rotate(143.17) scale(24.531)"
+      >
+        <stop stopColor="#3DAD8F" />
+        <stop offset="1" stopColor="#80DBC3" />
+      </radialGradient>
+    </defs>
+  </svg>
+)

--- a/apps/web/lib/prompts.tsx
+++ b/apps/web/lib/prompts.tsx
@@ -64,6 +64,16 @@ export const promptOptions: PromptOption[] = [
   },
   {
     type: "option",
+    id: PROMPT_TYPES.MAGIC_PATTERNS,
+    label: "Magic Patterns",
+    description: "Optimized for Magic Patterns",
+    action: "copy",
+    icon: (
+      <Icons.magicPatterns className="min-h-[18px] min-w-[18px] max-h-[18px] max-w-[18px]" />
+    ),
+  },
+  {
+    type: "option",
     id: PROMPT_TYPES.V0,
     label: "v0 by Vercel",
     description: "Optimized for v0.dev",
@@ -147,6 +157,55 @@ export const getComponentInstallPrompt = ({
   const componentDemoFileName = demoCodeFileName.split("/").slice(-1)[0]
 
   let prompt = ""
+
+  if (promptType === PROMPT_TYPES.MAGIC_PATTERNS) {
+    prompt =
+      "Take the following code of a React component and add it to the design.\n" +
+      endent`        
+        ${componentFileName}
+        ${code}
+      ` +
+      "\n Here is an example how to use the component:\n" +
+      endent`
+        ${componentDemoFileName}
+        ${demoCode}
+      ` +
+      "\n"
+
+    if (tailwindConfig) {
+      prompt +=
+        "\n" +
+        endent`
+        Extend existing tailwind.config.js with this code:
+        \`\`\`js
+        ${tailwindConfig}
+        \`\`\`
+      ` +
+        "\n"
+    }
+
+    if (globalCss) {
+      prompt +=
+        "\n" +
+        endent`
+        Extend existing index.css with this code:
+        \`\`\`css
+        ${globalCss}
+        \`\`\`
+      ` +
+        "\n"
+    }
+
+    prompt +=
+      "\n" +
+      endent`
+        IMPORTANT:
+          - Modify the component as needed to fit the existing codebase + design
+          - Extend the tailwind.config.js and index.css if needed to include additional variables or styles
+      `
+
+    return prompt
+  }
 
   if (promptType === PROMPT_TYPES.REPLIT) {
     prompt += "Build this as my initial prototype\n\n"

--- a/apps/web/lib/prompts.tsx
+++ b/apps/web/lib/prompts.tsx
@@ -165,7 +165,7 @@ export const getComponentInstallPrompt = ({
         ${componentFileName}
         ${code}
       ` +
-      "\n Here is an example how to use the component:\n" +
+      "\n Here is an example of how to use the component:\n" +
       endent`
         ${componentDemoFileName}
         ${demoCode}
@@ -176,7 +176,7 @@ export const getComponentInstallPrompt = ({
       prompt +=
         "\n" +
         endent`
-        Extend existing tailwind.config.js with this code:
+        Extend the existing tailwind.config.js (or create a new one if non-existent) with this code:
         \`\`\`js
         ${tailwindConfig}
         \`\`\`
@@ -188,10 +188,29 @@ export const getComponentInstallPrompt = ({
       prompt +=
         "\n" +
         endent`
-        Extend existing index.css with this code:
+        Extend the existing index.css (or create a new one if non-existent) with this code:
         \`\`\`css
         ${globalCss}
         \`\`\`
+      ` +
+        "\n"
+    }
+
+    if (Object.keys(registryDependencies || {}).length > 0) {
+      prompt +=
+        "\n" +
+        endent`
+        Copy-paste these files for dependencies:
+        ${Object.entries(registryDependencies)
+          .map(
+            ([fileName, fileContent]) => endent`
+            \`\`\`tsx
+            ${fileName}
+            ${fileContent}
+            \`\`\`
+          `,
+          )
+          .join("\n")}
       ` +
         "\n"
     }

--- a/apps/web/types/global.ts
+++ b/apps/web/types/global.ts
@@ -63,6 +63,7 @@ export const PROMPT_TYPES = {
   BOLT: "bolt",
   EXTENDED: "extended",
   REPLIT: "replit",
+  MAGIC_PATTERNS: "magic_patterns",
 } as const
 
 export type PromptType = (typeof PROMPT_TYPES)[keyof typeof PROMPT_TYPES]


### PR DESCRIPTION
Adding an optimized prompt for [Magic Patterns](https://www.magicpatterns.com).

We already have customers doing it manually so figured we'd make their lives a little easier!
![CleanShot 2025-02-03 at 21 01 19](https://github.com/user-attachments/assets/041f844d-80fa-498c-aa88-748090b8c7a9)

Some things to note:
- I had Magic Patterns run its own path in the function because its unique to the other app builders. We don't need the dependencies to be prompted. 

Happy to make edits & updates to this PR, already in love with this project!

Example created manually forming the prompt: https://www.magicpatterns.com/c/vAFuTGMuzmi6hJKBDjAzFC