### PR TITLE
fix: Fix Magic Patterns logo size to be 22 by 22

### DIFF
--- a/apps/web/components/icons/magic-patterns.tsx
+++ b/apps/web/components/icons/magic-patterns.tsx
@@ -1,7 +1,7 @@
 export const MagicPatternsLogo = ({ className }: { className?: string }) => (
   <svg
-    width="85"
-    height="85"
+    width="22"
+    height="22"
     viewBox="0 0 85 85"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/apps/web/components/icons/magic-patterns.tsx
+++ b/apps/web/components/icons/magic-patterns.tsx
@@ -1,7 +1,6 @@
 export const MagicPatternsLogo = ({ className }: { className?: string }) => (
   <svg
-    width="22"
-    height="22"
+    className={className}
     viewBox="0 0 85 85"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Not sure what happened as I don't think it was always like this, but right now on production, when Magic Patterns is selected, the svg is quite large. Huge apologies!! 

![CleanShot 2025-02-05 at 13 03 10@2x](https://github.com/user-attachments/assets/40133c30-fc53-4d1f-bc71-a114475af111)

This PR adjusts the size of the image to make it small again:

![CleanShot 2025-02-05 at 13 04 03@2x](https://github.com/user-attachments/assets/c00d75c2-064f-46fa-88f0-2f35b9a8a84a)


P.S. happy belated birthday @serafimcloud ! 🍰 
