### PR TITLE
Fix subpath imports

### DIFF
--- a/apps/web/lib/parsers.ts
+++ b/apps/web/lib/parsers.ts
@@ -122,6 +122,16 @@ export function extractNPMDependencies(code: string): Record<string, string> {
       )
     }
 
+    const getRootPackageName = (packageName: string) => {
+      const parts = packageName.split("/")
+      
+      if (parts.length > 1) {
+        return parts[0]
+      }
+      
+      return packageName;
+    }
+
     traverse(ast, {
       ImportDeclaration({ node }) {
         const importDeclaration = node as t.ImportDeclaration
@@ -132,10 +142,8 @@ export function extractNPMDependencies(code: string): Record<string, string> {
           !source.startsWith("/") &&
           !source.startsWith("@/")
         ) {
-          let packageName = source
-          if (packageName === "motion/react") {
-            packageName = "motion"
-          }
+          const packageName = getRootPackageName(source)
+
           if (shouldAddDependency(packageName)) {
             dependencies[packageName] = "latest"
           }
@@ -156,10 +164,8 @@ export function extractNPMDependencies(code: string): Record<string, string> {
             !source.startsWith("/") &&
             !source.startsWith("@/")
           ) {
-            let packageName = source
-            if (packageName === "motion/react") {
-              packageName = "motion"
-            }
+            const packageName = getRootPackageName(source)
+
             if (shouldAddDependency(packageName)) {
               dependencies[packageName] = "latest"
             }


### PR DESCRIPTION
This PR introduces a new helper function, `getRootPackageName` to extract the root package name from a given package string. This function handles cases where the package name includes a namespace or subpath.

The existing implementation was hardcoded for `motion` library, but there are many other packages with import structures like this, e.g. `media-chrome/react`.